### PR TITLE
gobf: extend memory and buffer size to 32768

### DIFF
--- a/bf/bf.go
+++ b/bf/bf.go
@@ -133,7 +133,7 @@ var abi amd64.ABI
 // The compiled code does no bounds-checking on the tape. On EOF or
 // other read error, `,' clears the current cell.
 func Compile(prog []byte, r io.Reader, w io.Writer) (func([]byte), error) {
-	buf, e := gojit.Alloc(gojit.PageSize * 4)
+	buf, e := gojit.Alloc(gojit.PageSize * 8)
 	if e != nil {
 		return nil, e
 	}

--- a/gobf/main.go
+++ b/gobf/main.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nelhage/gojit/bf"
 )
 
+const memorySize = 32768
+
 func main() {
 	var (
 		buffer = flag.Bool("buffer", false, "buffer stdout")
@@ -34,6 +36,6 @@ func main() {
 	if e != nil {
 		log.Fatalf("compiling: %s", e.Error())
 	}
-	var memory [4096]byte
+	var memory [memorySize]byte
 	f(memory[:])
 }


### PR DESCRIPTION
Extend memory and buffer size for larger BF programs.